### PR TITLE
Add push version check

### DIFF
--- a/encorecloud/pubsub.go
+++ b/encorecloud/pubsub.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -15,7 +17,9 @@ import (
 )
 
 const (
-	KeepAliveInterval = 5 * time.Second
+	KeepAliveInterval       = 5 * time.Second
+	PushVersionAcceptHeader = "X-Encore-Push-Accept-Version"
+	PushVersionHeader       = "X-Encore-Push-Version"
 )
 
 // PublishToTopic publishes the specified attrs and data to the topic specified by topicID.
@@ -47,6 +51,42 @@ func (c *Client) PublishToTopic(ctx context.Context, topicID string, attrs map[s
 // CreateSubscriptionHandler returns a [http.HandlerFunc] that can be used to handle
 // subscription push requests from EncoreCloud.
 //
+// The handler will call the provided callback function with the message ID and payload and will negotiate
+// the push version with the server, such that Encore Platform will send a list of supported versions and
+// this handler will respond with the highest version it supports. This allows for backwards compatibility
+// with older running applications without requiring them to be updated and redeployed.
+//
+// The handler will a 406 Not Acceptable error server cannot accept the request due to a newer push version.
+func (c *Client) CreateSubscriptionHandler(subscriptionID string, logger *zerolog.Logger, callback types.SubscriptionCallback) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		// Check the requested version is supported by this handler
+		// (for now only version 1 is supported, but this code allows "version 1, 2, 3" to be requested)
+		// and will allow this handler to respond with a version 1 response
+		requestedVersions := make(map[string]struct{})
+		for _, acceptStr := range req.Header.Values(PushVersionAcceptHeader) {
+			for _, version := range strings.Split(acceptStr, ",") {
+				requestedVersions[strings.TrimSpace(version)] = struct{}{}
+			}
+		}
+
+		if _, ok := requestedVersions["1"]; ok {
+			subscriptionHandlerV1(w, req, c, subscriptionID, logger, callback)
+			return
+		}
+
+		// If we get here, we don't support any of the requested versions
+		versionsStr := make([]string, 0, len(requestedVersions))
+		for version := range requestedVersions {
+			versionsStr = append(versionsStr, version)
+		}
+		sort.Strings(versionsStr)
+
+		err := fmt.Errorf("requested versions: %s", strings.Join(versionsStr, ", "))
+		logger.Err(err).Msg("PubSub push endpoint received request with versions it cannot accept")
+		jsonerr.Error(w, err, http.StatusNotAcceptable)
+	}
+}
+
 // Encore Cloud will send a POST request to the endpoint with a JSON encoded [pushPayload] as the body.
 // The request will be signed with the latest Encore Cloud auth key for this application.
 //
@@ -70,108 +110,107 @@ func (c *Client) PublishToTopic(ctx context.Context, topicID string, attrs map[s
 // - "keepalive" - A message to inform the server that the client is still processing.
 // - "ack" - A message to confirm the client has successfully processed the message.
 // - "nack" - A message to tell the server the client failed to process the message and it should be retried.
-func (c *Client) CreateSubscriptionHandler(subscriptionID string, logger *zerolog.Logger, callback types.SubscriptionCallback) http.HandlerFunc {
-	return func(w http.ResponseWriter, req *http.Request) {
-		// Decode the request
-		payload := &types.SubscriptionPushParams{}
-		err := c.client.VerifyAndDecodeRequest(
-			req,
-			auth.PubsubMsg, auth.Read,
-			payload,
-			[]byte(subscriptionID),
-		)
-		if err != nil {
-			logger.Err(err).Msg("error while verifying PubSub subscription message")
-			jsonerr.Error(w, err, http.StatusUnauthorized)
-			return
-		}
+func subscriptionHandlerV1(w http.ResponseWriter, req *http.Request, c *Client, subscriptionID string, logger *zerolog.Logger, callback types.SubscriptionCallback) {
+	// Decode the request
+	payload := &types.SubscriptionPushParams{}
+	err := c.client.VerifyAndDecodeRequest(
+		req,
+		auth.PubsubMsg, auth.Read,
+		payload,
+		[]byte(subscriptionID),
+	)
+	if err != nil {
+		logger.Err(err).Msg("error while verifying PubSub subscription message")
+		jsonerr.Error(w, err, http.StatusUnauthorized)
+		return
+	}
 
-		// Ensure we can flush the responses
-		flusher, ok := w.(http.Flusher)
-		if !ok {
-			err = errors.New("unable to cast http.ResponseWriter to http.Flusher")
-			logger.Err(err).Msg("error while setting up flushing response")
-			jsonerr.Error(w, err, http.StatusInternalServerError)
-			return
-		}
+	// Ensure we can flush the responses
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		err = errors.New("unable to cast http.ResponseWriter to http.Flusher")
+		logger.Err(err).Msg("error while setting up flushing response")
+		jsonerr.Error(w, err, http.StatusInternalServerError)
+		return
+	}
 
-		// Start the event stream
-		w.Header().Set("Content-Type", "text/event-stream")
-		w.Header().Set("Cache-Control", "no-cache")
-		w.Header().Set("Connection", "keep-alive")
-		w.WriteHeader(http.StatusOK)
-		flusher.Flush()
+	// Start the event stream
+	w.Header().Set(PushVersionHeader, "1")
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
 
-		// Run the subscription function in a goroutine
-		response := make(chan error, 1)
-		go func() {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("panic while processing PubSub message: %v", r)
-					response <- err
-				}
-				close(response)
-			}()
-
-			response <- callback(
-				req.Context(),
-				payload.MessageID, payload.PublishTime, payload.DeliveryAttempt,
-				payload.Attributes, payload.Data,
-			)
+	// Run the subscription function in a goroutine
+	response := make(chan error, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("panic while processing PubSub message: %v", r)
+				response <- err
+			}
+			close(response)
 		}()
 
-		// Wait for the function to complete or the request to be cancelled
-		var firstError error
-		var finished bool
-		keepAliveTimeout := time.NewTicker(KeepAliveInterval)
-		defer keepAliveTimeout.Stop()
+		response <- callback(
+			req.Context(),
+			payload.MessageID, payload.PublishTime, payload.DeliveryAttempt,
+			payload.Attributes, payload.Data,
+		)
+	}()
 
-		for !finished {
-			select {
-			case <-req.Context().Done():
-				logger.Err(err).Msg("PubSub push endpoint closed by Encore Cloud before subscription function completed")
-				return
+	// Wait for the function to complete or the request to be cancelled
+	var firstError error
+	var finished bool
+	keepAliveTimeout := time.NewTicker(KeepAliveInterval)
+	defer keepAliveTimeout.Stop()
 
-			case <-keepAliveTimeout.C:
-				// Send a keepalive message
-				if _, err := fmt.Fprintf(w, "event: keepalive\ndata: \n\n"); err != nil {
-					logger.Err(err).Msg("error while sending keepalive message")
-				}
-				flusher.Flush()
-
-			case err, done := <-response:
-				if done {
-					finished = true
-				} else if firstError == nil {
-					firstError = err
-				}
-			}
-		}
-
-		// Now that the subscription function has completed, send the end message
-		if firstError != nil {
-			logger.Err(firstError).Msg("error while handling PubSub subscription message")
-
-			if _, err := fmt.Fprintf(w, "event: nack\ndata: %s\n\n", firstError.Error()); err != nil {
-				logger.Err(err).Msg("error while sending nack message")
-			}
-		} else {
-			if _, err := fmt.Fprintf(w, "event: ack\ndata: \n\n"); err != nil {
-				logger.Err(err).Msg("error while sending ack message")
-			}
-		}
-		flusher.Flush()
-
-		// Now wait for the request to be closed by Encore Cloud (upto 5 seconds)
+	for !finished {
 		select {
 		case <-req.Context().Done():
-			// If the request is closed by Encore Cloud, the context will be cancelled, this is a sign that it has processed
-			// our end message successfully
+			logger.Err(err).Msg("PubSub push endpoint closed by Encore Cloud before subscription function completed")
+			return
 
-		case <-time.After(KeepAliveInterval):
-			// If we get here, the request was not closed by Encore Cloud, so we should log an error
-			// and return
-			logger.Err(err).Msg("PubSub push connection was not closed by Encore Cloud after ack/nack message sent")
+		case <-keepAliveTimeout.C:
+			// Send a keepalive message
+			if _, err := fmt.Fprintf(w, "event: keepalive\ndata: \n\n"); err != nil {
+				logger.Err(err).Msg("error while sending keepalive message")
+			}
+			flusher.Flush()
+
+		case err, done := <-response:
+			if done {
+				finished = true
+			} else if firstError == nil {
+				firstError = err
+			}
 		}
+	}
+
+	// Now that the subscription function has completed, send the end message
+	if firstError != nil {
+		logger.Err(firstError).Msg("error while handling PubSub subscription message")
+
+		if _, err := fmt.Fprintf(w, "event: nack\ndata: %s\n\n", firstError.Error()); err != nil {
+			logger.Err(err).Msg("error while sending nack message")
+		}
+	} else {
+		if _, err := fmt.Fprintf(w, "event: ack\ndata: \n\n"); err != nil {
+			logger.Err(err).Msg("error while sending ack message")
+		}
+	}
+	flusher.Flush()
+
+	// Now wait for the request to be closed by Encore Cloud (upto 5 seconds)
+	select {
+	case <-req.Context().Done():
+		// If the request is closed by Encore Cloud, the context will be cancelled, this is a sign that it has processed
+		// our end message successfully
+
+	case <-time.After(KeepAliveInterval):
+		// If we get here, the request was not closed by Encore Cloud, so we should log an error
+		// and return
+		logger.Err(err).Msg("PubSub push connection was not closed by Encore Cloud after ack/nack message sent")
 	}
 }

--- a/encorecloud/types/pubsub.go
+++ b/encorecloud/types/pubsub.go
@@ -9,8 +9,9 @@ import (
 
 // PublishParams is the parameters for publishing a message to a topic.
 type PublishParams struct {
-	Attributes map[string]string `json:"attributes,omitempty" encore:"sensitive"` // Optional attributes for this message.
-	Payload    json.RawMessage   `json:"payload" encore:"sensitive"`              // The message payload.
+	Attributes  map[string]string `json:"attributes,omitempty" encore:"sensitive"`   // Optional attributes for this message.
+	OrderingKey string            `json:"ordering_key,omitempty" encore:"sensitive"` // Optional grouping key for this message.
+	Payload     json.RawMessage   `json:"payload" encore:"sensitive"`                // The message payload.
 }
 
 func (p *PublishParams) DeterministicBytes() []byte {


### PR DESCRIPTION
This commit adds a subscription push version negation to the subscription handler allowing us to upgrade the method of communication in the future without needing to redeploy applications.

It also adds an ordering key to the SDK's publish command to allow for ordered pubsub.