### PR TITLE
Remove connection close check after sub handler

### DIFF
--- a/encorecloud/pubsub.go
+++ b/encorecloud/pubsub.go
@@ -207,16 +207,4 @@ func subscriptionHandlerV1(w http.ResponseWriter, req *http.Request, c *Client, 
 		}
 	}
 	flusher.Flush()
-
-	// Now wait for the request to be closed by Encore Cloud (upto 5 seconds)
-	select {
-	case <-req.Context().Done():
-		// If the request is closed by Encore Cloud, the context will be cancelled, this is a sign that it has processed
-		// our end message successfully
-
-	case <-time.After(KeepAliveInterval):
-		// If we get here, the request was not closed by Encore Cloud, so we should log an error
-		// and return
-		logger.Err(err).Msg("PubSub push connection was not closed by Encore Cloud after ack/nack message sent")
-	}
 }


### PR DESCRIPTION
Encore Cloud Entwined used the http.DefaultTransport which is using an idle timeout of 90s. The connection established to push each subscription message is configured as keep-alive. Therefore the connection won't be closed until after 90s of connection idle time. 

This PR removes a check that Encore Cloud closes the connection after each acked message.
